### PR TITLE
Add cargo config for simd-json

### DIFF
--- a/rust_bencher/.cargo/config
+++ b/rust_bencher/.cargo/config
@@ -1,0 +1,2 @@
+[build]
+rustflags = ["-C", "target-cpu=native"]


### PR DESCRIPTION
Informs cargo to use native extensions so that simd-json dep builds
cleanly:

```
➜  rust_bencher git:(fix-rust-bench-for-simd-json) ✗ ./target/debug/rust_bencher simdjson
Time simdjson: 300622 mills
```